### PR TITLE
Add the babel-cli as a dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "install": "npm run build"
   },
   "devDependencies": {
+    "babel-cli": "^6.4.5",
     "babel-plugin-add-module-exports": "^0.1.2",
     "madewithlove-webpack-config": "github:madewithlove/webpack-config",
     "react": "^0.14.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "madewithlove-webpack-config": "github:madewithlove/webpack-config",
     "react": "^0.14.6",
     "webpack": "^1.12.11",


### PR DESCRIPTION
The post-install script needs the babel-cli as a dependency so I've added it.
